### PR TITLE
timeout interceptor

### DIFF
--- a/src/common/interceptors/timeout.interceptor.ts
+++ b/src/common/interceptors/timeout.interceptor.ts
@@ -1,0 +1,18 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { timeout } from 'rxjs/operators';
+
+@Injectable()
+export class TimeOutInterceptor implements NestInterceptor {
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>,
+  ): Observable<any> | Promise<Observable<any>> {
+    return next.handle().pipe(timeout(3000));
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,13 @@ import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { AllExceptionFilter } from './common/filters/http-exception.filter';
+import { TimeOutInterceptor } from './common/interceptors/timeout.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe());
   app.useGlobalFilters(new AllExceptionFilter());
+  app.useGlobalInterceptors(new TimeOutInterceptor());
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
interceptor was created to return error when any endpoint take more than 3 seconds